### PR TITLE
Adds single type sections to Strapi

### DIFF
--- a/src/api/amenity/content-types/amenity/schema.json
+++ b/src/api/amenity/content-types/amenity/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "singleType",
+  "collectionName": "amenities",
+  "info": {
+    "singularName": "amenity",
+    "pluralName": "amenities",
+    "displayName": "Amenity Section",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "img": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    }
+  }
+}

--- a/src/api/amenity/controllers/amenity.js
+++ b/src/api/amenity/controllers/amenity.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * amenity controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::amenity.amenity');

--- a/src/api/amenity/routes/amenity.js
+++ b/src/api/amenity/routes/amenity.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * amenity router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::amenity.amenity');

--- a/src/api/amenity/services/amenity.js
+++ b/src/api/amenity/services/amenity.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * amenity service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::amenity.amenity');

--- a/src/api/hero-section/content-types/hero-section/schema.json
+++ b/src/api/hero-section/content-types/hero-section/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "singleType",
+  "collectionName": "hero_sections",
+  "info": {
+    "singularName": "hero-section",
+    "pluralName": "hero-sections",
+    "displayName": "Hero Section",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "img": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    }
+  }
+}

--- a/src/api/hero-section/controllers/hero-section.js
+++ b/src/api/hero-section/controllers/hero-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * hero-section controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::hero-section.hero-section');

--- a/src/api/hero-section/routes/hero-section.js
+++ b/src/api/hero-section/routes/hero-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * hero-section router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::hero-section.hero-section');

--- a/src/api/hero-section/services/hero-section.js
+++ b/src/api/hero-section/services/hero-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * hero-section service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::hero-section.hero-section');

--- a/src/api/property-section/content-types/property-section/schema.json
+++ b/src/api/property-section/content-types/property-section/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "singleType",
+  "collectionName": "property_sections",
+  "info": {
+    "singularName": "property-section",
+    "pluralName": "property-sections",
+    "displayName": "Property Section ",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "img": {
+      "type": "media",
+      "multiple": true,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    }
+  }
+}

--- a/src/api/property-section/controllers/property-section.js
+++ b/src/api/property-section/controllers/property-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * property-section controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::property-section.property-section');

--- a/src/api/property-section/routes/property-section.js
+++ b/src/api/property-section/routes/property-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * property-section router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::property-section.property-section');

--- a/src/api/property-section/services/property-section.js
+++ b/src/api/property-section/services/property-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * property-section service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::property-section.property-section');

--- a/src/api/safety-and-hygiene/content-types/safety-and-hygiene/schema.json
+++ b/src/api/safety-and-hygiene/content-types/safety-and-hygiene/schema.json
@@ -1,0 +1,25 @@
+{
+  "kind": "singleType",
+  "collectionName": "safety_and_hygienes",
+  "info": {
+    "singularName": "safety-and-hygiene",
+    "pluralName": "safety-and-hygienes",
+    "displayName": "Safety and Hygiene"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "img": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": true
+    }
+  }
+}

--- a/src/api/safety-and-hygiene/controllers/safety-and-hygiene.js
+++ b/src/api/safety-and-hygiene/controllers/safety-and-hygiene.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * safety-and-hygiene controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::safety-and-hygiene.safety-and-hygiene');

--- a/src/api/safety-and-hygiene/routes/safety-and-hygiene.js
+++ b/src/api/safety-and-hygiene/routes/safety-and-hygiene.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * safety-and-hygiene router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::safety-and-hygiene.safety-and-hygiene');

--- a/src/api/safety-and-hygiene/services/safety-and-hygiene.js
+++ b/src/api/safety-and-hygiene/services/safety-and-hygiene.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * safety-and-hygiene service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::safety-and-hygiene.safety-and-hygiene');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -369,6 +369,35 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiAmenityAmenity extends Struct.SingleTypeSchema {
+  collectionName: 'amenities';
+  info: {
+    description: '';
+    displayName: 'Amenity Section';
+    pluralName: 'amenities';
+    singularName: 'amenity';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    img: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::amenity.amenity'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiBookingBooking extends Struct.CollectionTypeSchema {
   collectionName: 'bookings';
   info: {
@@ -420,6 +449,35 @@ export interface ApiBookingBooking extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiHeroSectionHeroSection extends Struct.SingleTypeSchema {
+  collectionName: 'hero_sections';
+  info: {
+    description: '';
+    displayName: 'Hero Section';
+    pluralName: 'hero-sections';
+    singularName: 'hero-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    img: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::hero-section.hero-section'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiHotelHotel extends Struct.CollectionTypeSchema {
   collectionName: 'hotels';
   info: {
@@ -442,6 +500,36 @@ export interface ApiHotelHotel extends Struct.CollectionTypeSchema {
     logo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
     name: Schema.Attribute.String;
     phone: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiPropertySectionPropertySection
+  extends Struct.SingleTypeSchema {
+  collectionName: 'property_sections';
+  info: {
+    description: '';
+    displayName: 'Property Section ';
+    pluralName: 'property-sections';
+    singularName: 'property-section';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    img: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios', true>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::property-section.property-section'
+    > &
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
@@ -513,6 +601,35 @@ export interface ApiRoomRoom extends Struct.CollectionTypeSchema {
       ['Available', 'Cleaning', 'Occupied']
     > &
       Schema.Attribute.DefaultTo<'Available'>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiSafetyAndHygieneSafetyAndHygiene
+  extends Struct.SingleTypeSchema {
+  collectionName: 'safety_and_hygienes';
+  info: {
+    displayName: 'Safety and Hygiene';
+    pluralName: 'safety-and-hygienes';
+    singularName: 'safety-and-hygiene';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    img: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios', true>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::safety-and-hygiene.safety-and-hygiene'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -1101,10 +1218,14 @@ declare module '@strapi/strapi' {
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
+      'api::amenity.amenity': ApiAmenityAmenity;
       'api::booking.booking': ApiBookingBooking;
+      'api::hero-section.hero-section': ApiHeroSectionHeroSection;
       'api::hotel.hotel': ApiHotelHotel;
+      'api::property-section.property-section': ApiPropertySectionPropertySection;
       'api::reservation.reservation': ApiReservationReservation;
       'api::room.room': ApiRoomRoom;
+      'api::safety-and-hygiene.safety-and-hygiene': ApiSafetyAndHygieneSafetyAndHygiene;
       'api::service-usage.service-usage': ApiServiceUsageServiceUsage;
       'api::service.service': ApiServiceService;
       'plugin::content-releases.release': PluginContentReleasesRelease;


### PR DESCRIPTION
Adds "Amenity Section", "Hero Section", "Property Section", and "Safety and Hygiene" single type sections to the Strapi backend with an image upload field. These sections allow admins to manage content for specific areas of the application.

The "Property Section" and "Safety and Hygiene" single types support multiple images, while "Amenity Section" and "Hero Section" support a single image.